### PR TITLE
Name the nodes in pandas-iris

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,6 +139,7 @@ cython_debug/
 
 # Pycharm
 .idea/
+*.iml
 
 # VSCode
 .vscode/*

--- a/pandas-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/pipelines/data_engineering/pipeline.py
+++ b/pandas-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/pipelines/data_engineering/pipeline.py
@@ -49,6 +49,7 @@ def create_pipeline(**kwargs):
                     test_x="example_test_x",
                     test_y="example_test_y",
                 ),
+                name="split_data"
             )
         ]
     )

--- a/pandas-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/pipelines/data_engineering/pipeline.py
+++ b/pandas-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/pipelines/data_engineering/pipeline.py
@@ -49,7 +49,7 @@ def create_pipeline(**kwargs):
                     test_x="example_test_x",
                     test_y="example_test_y",
                 ),
-                name="split_data"
+                name="split"
             )
         ]
     )

--- a/pandas-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/pipelines/data_science/pipeline.py
+++ b/pandas-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/pipelines/data_science/pipeline.py
@@ -44,7 +44,7 @@ def create_pipeline(**kwargs):
                 train_model,
                 ["example_train_x", "example_train_y", "parameters"],
                 "example_model",
-                name="train_model"
+                name="train"
             ),
             node(
                 predict,
@@ -56,6 +56,6 @@ def create_pipeline(**kwargs):
                 report_accuracy,
                 ["example_predictions", "example_test_y"],
                 None,
-                name="report_accuracy"),
+                name="report"),
         ]
     )

--- a/pandas-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/pipelines/data_science/pipeline.py
+++ b/pandas-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/pipelines/data_science/pipeline.py
@@ -44,12 +44,18 @@ def create_pipeline(**kwargs):
                 train_model,
                 ["example_train_x", "example_train_y", "parameters"],
                 "example_model",
+                name="train_model"
             ),
             node(
                 predict,
                 dict(model="example_model", test_x="example_test_x"),
                 "example_predictions",
+                name="predict"
             ),
-            node(report_accuracy, ["example_predictions", "example_test_y"], None),
+            node(
+                report_accuracy,
+                ["example_predictions", "example_test_y"],
+                None,
+                name="report_accuracy"),
         ]
     )


### PR DESCRIPTION
The nodes of pandas-iris are unnamed and that results in some very long autogenerated names. Some deployment tutorials depend on this starter as an example and sometimes the unfriendly names of the nodes makes it harder for the reader to understand what is happening.