### PR TITLE
Update prompts.yml to move default to cookiecutter.json

### DIFF
--- a/astro-iris/cookiecutter.json
+++ b/astro-iris/cookiecutter.json
@@ -1,5 +1,5 @@
 {
-    "project_name": "default",
+    "project_name": "New Kedro Project",
     "repo_name": "{{ cookiecutter.project_name.replace(' ', '-').lower().strip('-') }}",
     "python_package": "{{ cookiecutter.project_name.replace(' ', '_').lower().strip('-') }}",
     "kedro_version": "{{ cookiecutter.kedro_version }}"

--- a/astro-iris/prompts.yml
+++ b/astro-iris/prompts.yml
@@ -3,7 +3,6 @@ project_name:
   text: |
     Please enter a human readable name for your new project.
     Spaces and punctuation are allowed.
-  default: New Kedro Project
 
 repo_name:
   title: "Repository Name:"
@@ -12,7 +11,7 @@ repo_name:
     Alphanumeric characters, hyphens and underscores are allowed.
     Lowercase is recommended.
   regex_validator: "^\\w+(-*\\w+)*$"
-  error_msg: |
+  error_message: |
     It must contain only word symbols and/or hyphens, must also
     start and end with alphanumeric symbol."
 
@@ -24,6 +23,6 @@ python_package:
     Lowercase is recommended. Package name must start with a letter
     or underscore.
   regex_validator: "^[a-zA-Z_]\\w{1,}$"
-  error_msg: |
+  error_message: |
     It must start with a letter or underscore, be at least 2 characters long
     and contain only letters, digits, and/or underscores.

--- a/mini-kedro/prompts.yml
+++ b/mini-kedro/prompts.yml
@@ -3,7 +3,6 @@ project_name:
   text: |
     Please enter a human readable name for your new project.
     Spaces and punctuation are allowed.
-  default: New Kedro Project
 
 repo_name:
   title: "Repository Name:"
@@ -12,6 +11,6 @@ repo_name:
     Alphanumeric characters, hyphens and underscores are allowed.
     Lowercase is recommended.
   regex_validator: "^\\w+(-*\\w+)*$"
-  error_msg: |
+  error_message: |
     It must contain only word symbols and/or hyphens, must also
     start and end with alphanumeric symbol."

--- a/pandas-iris/cookiecutter.json
+++ b/pandas-iris/cookiecutter.json
@@ -1,5 +1,5 @@
 {
-    "project_name": "default",
+    "project_name": "New Kedro Project",
     "repo_name": "{{ cookiecutter.project_name.replace(' ', '-').lower().strip('-') }}",
     "python_package": "{{ cookiecutter.project_name.replace(' ', '_').lower().strip('-') }}",
     "kedro_version": "{{ cookiecutter.kedro_version }}"

--- a/pandas-iris/prompts.yml
+++ b/pandas-iris/prompts.yml
@@ -3,7 +3,6 @@ project_name:
   text: |
     Please enter a human readable name for your new project.
     Spaces and punctuation are allowed.
-  default: New Kedro Project
 
 repo_name:
   title: "Repository Name:"
@@ -12,7 +11,7 @@ repo_name:
     Alphanumeric characters, hyphens and underscores are allowed.
     Lowercase is recommended.
   regex_validator: "^\\w+(-*\\w+)*$"
-  error_msg: |
+  error_message: |
     It must contain only word symbols and/or hyphens, must also
     start and end with alphanumeric symbol."
 
@@ -24,6 +23,6 @@ python_package:
     Lowercase is recommended. Package name must start with a letter
     or underscore.
   regex_validator: "^[a-zA-Z_]\\w{1,}$"
-  error_msg: |
+  error_message: |
     It must start with a letter or underscore, be at least 2 characters long
     and contain only letters, digits, and/or underscores.

--- a/pyspark-iris/cookiecutter.json
+++ b/pyspark-iris/cookiecutter.json
@@ -1,5 +1,5 @@
 {
-    "project_name": "default",
+    "project_name": "New Kedro Project",
     "repo_name": "{{ cookiecutter.project_name.replace(' ', '-').lower().strip('-') }}",
     "python_package": "{{ cookiecutter.project_name.replace(' ', '_').lower().strip('-') }}",
     "kedro_version": "{{ cookiecutter.kedro_version }}"

--- a/pyspark-iris/prompts.yml
+++ b/pyspark-iris/prompts.yml
@@ -3,7 +3,6 @@ project_name:
   text: |
     Please enter a human readable name for your new project.
     Spaces and punctuation are allowed.
-  default: New Kedro Project
 
 repo_name:
   title: "Repository Name:"
@@ -12,7 +11,7 @@ repo_name:
     Alphanumeric characters, hyphens and underscores are allowed.
     Lowercase is recommended.
   regex_validator: "^\\w+(-*\\w+)*$"
-  error_msg: |
+  error_message: |
     It must contain only word symbols and/or hyphens, must also
     start and end with alphanumeric symbol."
 
@@ -24,6 +23,6 @@ python_package:
     Lowercase is recommended. Package name must start with a letter
     or underscore.
   regex_validator: "^[a-zA-Z_]\\w{1,}$"
-  error_msg: |
+  error_message: |
     It must start with a letter or underscore, be at least 2 characters long
     and contain only letters, digits, and/or underscores.

--- a/pyspark/cookiecutter.json
+++ b/pyspark/cookiecutter.json
@@ -1,5 +1,5 @@
 {
-    "project_name": "default",
+    "project_name": "New Kedro Project",
     "repo_name": "{{ cookiecutter.project_name.replace(' ', '-').lower().strip('-') }}",
     "python_package": "{{ cookiecutter.project_name.replace(' ', '_').lower().strip('-') }}",
     "kedro_version": "{{ cookiecutter.kedro_version }}"

--- a/pyspark/prompts.yml
+++ b/pyspark/prompts.yml
@@ -3,7 +3,6 @@ project_name:
   text: |
     Please enter a human readable name for your new project.
     Spaces and punctuation are allowed.
-  default: New Kedro Project
 
 repo_name:
   title: "Repository Name:"
@@ -12,7 +11,7 @@ repo_name:
     Alphanumeric characters, hyphens and underscores are allowed.
     Lowercase is recommended.
   regex_validator: "^\\w+(-*\\w+)*$"
-  error_msg: |
+  error_message: |
     It must contain only word symbols and/or hyphens, must also
     start and end with alphanumeric symbol."
 
@@ -24,6 +23,6 @@ python_package:
     Lowercase is recommended. Package name must start with a letter
     or underscore.
   regex_validator: "^[a-zA-Z_]\\w{1,}$"
-  error_msg: |
+  error_message: |
     It must start with a letter or underscore, be at least 2 characters long
     and contain only letters, digits, and/or underscores.

--- a/spaceflights/cookiecutter.json
+++ b/spaceflights/cookiecutter.json
@@ -1,5 +1,5 @@
 {
-    "project_name": "default",
+    "project_name": "New Kedro Project",
     "repo_name": "{{ cookiecutter.project_name.replace(' ', '-').lower().strip('-') }}",
     "python_package": "{{ cookiecutter.project_name.replace(' ', '_').lower().strip('-') }}",
     "kedro_version": "{{ cookiecutter.kedro_version }}"

--- a/spaceflights/prompts.yml
+++ b/spaceflights/prompts.yml
@@ -3,7 +3,6 @@ project_name:
   text: |
     Please enter a human readable name for your new project.
     Spaces and punctuation are allowed.
-  default: New Kedro Project
 
 repo_name:
   title: "Repository Name:"
@@ -12,7 +11,7 @@ repo_name:
     Alphanumeric characters, hyphens and underscores are allowed.
     Lowercase is recommended.
   regex_validator: "^\\w+(-*\\w+)*$"
-  error_msg: |
+  error_message: |
     It must contain only word symbols and/or hyphens, must also
     start and end with alphanumeric symbol."
 
@@ -24,6 +23,6 @@ python_package:
     Lowercase is recommended. Package name must start with a letter
     or underscore.
   regex_validator: "^[a-zA-Z_]\\w{1,}$"
-  error_msg: |
+  error_message: |
     It must start with a letter or underscore, be at least 2 characters long
     and contain only letters, digits, and/or underscores.


### PR DESCRIPTION
This PR makes sure that `kedro new` in 0.17.1 will respect `cookiecutter.json` default values.