### PR TITLE
Fix/requirements interdependencies

### DIFF
--- a/features/steps/run_steps.py
+++ b/features/steps/run_steps.py
@@ -46,8 +46,6 @@ def create_project_from_config_file(context, starter_name):
 
 @given("I have installed the Kedro project's dependencies")
 def install_project_dependencies(context):
-    # breakpoint()
-    # res = subprocess.run([context.kedro, "install"], cwd=context.root_project_dir)
     res = subprocess.run(
         [context.pip, "install", "-r", "requirements.txt"],
         cwd=context.root_project_dir / "src",

--- a/features/steps/run_steps.py
+++ b/features/steps/run_steps.py
@@ -46,7 +46,12 @@ def create_project_from_config_file(context, starter_name):
 
 @given("I have installed the Kedro project's dependencies")
 def install_project_dependencies(context):
-    res = subprocess.run([context.kedro, "install"], cwd=context.root_project_dir)
+    # breakpoint()
+    # res = subprocess.run([context.kedro, "install"], cwd=context.root_project_dir)
+    res = subprocess.run(
+        [context.pip, "install", "-r", "requirements.txt"],
+        cwd=context.root_project_dir / "src",
+    )
     assert res.returncode == OK_EXIT_CODE
 
 
@@ -68,6 +73,7 @@ def list_kedro_pipelines(context):
 
 @when("I lint the project")
 def lint_project(context):
+    breakpoint()
     context.result = subprocess.run(
         [context.kedro, "lint", "--check-only"], cwd=context.root_project_dir
     )

--- a/features/steps/run_steps.py
+++ b/features/steps/run_steps.py
@@ -73,7 +73,6 @@ def list_kedro_pipelines(context):
 
 @when("I lint the project")
 def lint_project(context):
-    breakpoint()
     context.result = subprocess.run(
         [context.kedro, "lint", "--check-only"], cwd=context.root_project_dir
     )

--- a/features/steps/run_steps.py
+++ b/features/steps/run_steps.py
@@ -47,8 +47,7 @@ def create_project_from_config_file(context, starter_name):
 @given("I have installed the Kedro project's dependencies")
 def install_project_dependencies(context):
     res = subprocess.run(
-        [context.pip, "install", "-r", "requirements.txt"],
-        cwd=context.root_project_dir / "src",
+        [context.kedro, "install", "--no-build-reqs"], cwd=context.root_project_dir
     )
     assert res.returncode == OK_EXIT_CODE
 


### PR DESCRIPTION
## Situation
`master` is broken on [_kedro-starters_](https://github.com/quantumblacklabs/kedro-starters)

## Cause (high level)
_kedro-starters_ seems to have broken when [this PR](https://github.com/quantumblacklabs/private-kedro/pull/1126) merged to _private-kedro_. 

## Cause (detailed)
In a nutshell, kedro's `requirements.txt` is in conflict (`master` branch vs 0.17.3 release). This conflict is triggered as part of _kedro-starters_' CI as follows:
* CI for _kedro-starters_ first `pip install`s `test_requirements.txt` ([source code](https://github.com/quantumblacklabs/kedro-starters/blob/master/features/environment.py#L70)). This file refers to the `master` branch from _private-kedro_ ([source code](https://github.com/quantumblacklabs/kedro-starters/blob/master/test_requirements.txt#L6)). The `master` branch has upgraded requirements after [the abovementioned PR](https://github.com/quantumblacklabs/private-kedro/pull/1126) merged. In particular, it has upgraded requirement `python-json-logger~=2.0` for kedro itself ([diff](https://github.com/quantumblacklabs/private-kedro/pull/1126/files#diff-4d7c51b1efe9043e44439a949dfd92e5827321b34082903477fd04876edb7552R12))
* CI for _kedro-starters_ then installs project specific dependencies ([source code](https://github.com/quantumblacklabs/kedro-starters/blob/master/features/run.feature#L6)). In many cases, these project specific dependencies contain (part of) kedro itself (e.g. `kedro[pandas.CSVDataSet]=={{ cookiecutter.kedro_version }}` [here](https://github.com/quantumblacklabs/kedro-starters/blob/master/pandas-iris/%7B%7B%20cookiecutter.repo_name%20%7D%7D/src/requirements.txt) for `pandas-iris`). Unlike before, this doesn't point to _private-kedro_'s `master` branch, but to kedro's 0.17.3 release, which does _not_ have upgraded requirements. On top of that, installation this time happens through `kedro install`
* `kedro install`ing is the source of the problem. This is because, under the hood, it does a `pip compile` ([source code](https://github.com/quantumblacklabs/private-kedro/blob/master/kedro/framework/cli/project.py#L159)). Doing a `pip compile` on a requirement like `kedro[pandas.CSVDataSet]==0.17.3` results in `pip` recursively searching for the requirements of `kedro==0.17.3`. The 0.17.3 release has requirement `python-json-logger~=0.1.9` -> conflict with `python-json-logger~=2.0` from first bullet -> CI crashes -> broken _kedro-starters_ `master`


## Why was `python-json-logger` upgraded?
At the time, `python-json-logger` was bumped from `~=0.1.9` to `~=2.0` as a _nice-to-have_ given the pre-upgrade version [doesn't even officially support python 3.8](https://github.com/madzak/python-json-logger/blob/master/CHANGELOG.md)

## Possible solutions
1. **[This PR]** Avoid `pip compile` as part of _kedro_starters_ CI (notice CI passes)
2. [[Link to PR]](https://github.com/quantumblacklabs/private-kedro/pull/1135) Open up `python-json-logger` version window (CI assessment for _kedro_starters_ only possible after the merge)

## Discussion & questions to the Team
Out of the two alternatives above, I personally have a preference for 1., as it will also avoid similar problems in the future (which I guess would happen often, i.e. everytime kedro's `requirements.txt` is updated). Which brings me to the question(s):

A. How has this been handled in the past? Am I missing any obvious solution or making a problem out of something trivial (repos interdependencies)?

B. If it comes down to one of the two alternatives above, do we prefer 1. or 2.?

## Ticket for further work
https://jira.quantumblack.com/browse/KED-2691