### PR TITLE
[KED-2643] Fix circular dependency on pyspark starters

### DIFF
--- a/pyspark-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/context.py
+++ b/pyspark-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/context.py
@@ -27,12 +27,23 @@
 # limitations under the License.
 
 """Entry point for running a Kedro pipeline as a Python package."""
+import logging
 from pathlib import Path
 from typing import Any, Dict, Union
 
 from kedro.framework.context import KedroContext
-from pyspark import SparkConf
-from pyspark.sql import SparkSession
+
+logger = logging.getLogger(__name__)
+
+try:
+    from pyspark import SparkConf
+    from pyspark.sql import SparkSession
+except ModuleNotFoundError:
+    logger.warning(
+        "Could not import pyspark. Please ensure pyspark is installed "
+        "before running any pipeline. You can use 'kedro install' to "
+        "install project dependencies."
+    )
 
 
 class ProjectContext(KedroContext):

--- a/pyspark/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/context.py
+++ b/pyspark/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/context.py
@@ -27,12 +27,23 @@
 # limitations under the License.
 
 """Entry point for running a Kedro pipeline as a Python package."""
+import logging
 from pathlib import Path
 from typing import Any, Dict, Union
 
 from kedro.framework.context import KedroContext
-from pyspark import SparkConf
-from pyspark.sql import SparkSession
+
+logger = logging.getLogger(__name__)
+
+try:
+    from pyspark import SparkConf
+    from pyspark.sql import SparkSession
+except ModuleNotFoundError:
+    logger.warning(
+        "Could not import pyspark. Please ensure pyspark is installed "
+        "before running any pipeline. You can use 'kedro install' to "
+        "install project dependencies."
+    )
 
 
 class ProjectContext(KedroContext):

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -4,7 +4,3 @@ black==21.5b1
 click<8.0
 isort~=5.0
 git+https://github.com/quantumblacklabs/kedro.git@master#egg=kedro
-# reqs for `SparkDataSet`
-pyspark>=2.2, <4.0
-hdfs>=2.5.8, <3.0
-s3fs>=0.3.0, <0.5


### PR DESCRIPTION
## Description
https://jira.quantumblack.com/browse/KED-2643
https://github.com/quantumblacklabs/kedro/issues/767

## Development notes
* The issue was happenning on all pyspark starters (_pyspark_ and _pyspark-iris_).
* I was surprised this wasn't caught by CI, given that [our e2e tests invoke `kedro install`](https://github.com/quantumblacklabs/kedro-starters/blob/master/features/run.feature#L20). The issue was masked on CI because we had pyspark & others in `test_requirements.txt`, which [get installed prior to calling `kedro install`](https://github.com/quantumblacklabs/kedro-starters/blob/master/.circleci/config.yml#L32). This PR removes them.
* As an additional benefit, CI is ~20-30% faster now that we don't install pyspark & co for the e2e tests of every single starter.

## Checklist

- [x] Read the [contributing](https://github.com/quantumblacklabs/kedro/blob/master/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change and added my name to the list of supporting contributions in the [`RELEASE.md`](https://github.com/quantumblacklabs/kedro/blob/master/RELEASE.md) file
- [ ] Added tests to cover my changes

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
