### PR TITLE
[KED-2768] Fix Kedro install flow

### DIFF
--- a/pyspark-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/context.py
+++ b/pyspark-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/context.py
@@ -27,23 +27,12 @@
 # limitations under the License.
 
 """Entry point for running a Kedro pipeline as a Python package."""
-import logging
 from pathlib import Path
 from typing import Any, Dict, Union
 
 from kedro.framework.context import KedroContext
-
-logger = logging.getLogger(__name__)
-
-try:
-    from pyspark import SparkConf
-    from pyspark.sql import SparkSession
-except ModuleNotFoundError:
-    logger.warning(
-        "Could not import pyspark. Please ensure pyspark is installed "
-        "before running any pipeline. You can use 'kedro install' to "
-        "install project dependencies."
-    )
+from pyspark import SparkConf
+from pyspark.sql import SparkSession
 
 
 class ProjectContext(KedroContext):

--- a/pyspark/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/context.py
+++ b/pyspark/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/context.py
@@ -27,23 +27,12 @@
 # limitations under the License.
 
 """Entry point for running a Kedro pipeline as a Python package."""
-import logging
 from pathlib import Path
 from typing import Any, Dict, Union
 
 from kedro.framework.context import KedroContext
-
-logger = logging.getLogger(__name__)
-
-try:
-    from pyspark import SparkConf
-    from pyspark.sql import SparkSession
-except ModuleNotFoundError:
-    logger.warning(
-        "Could not import pyspark. Please ensure pyspark is installed "
-        "before running any pipeline. You can use 'kedro install' to "
-        "install project dependencies."
-    )
+from pyspark import SparkConf
+from pyspark.sql import SparkSession
 
 
 class ProjectContext(KedroContext):


### PR DESCRIPTION
This PR removes the temporary fix implemented as part of [[KED-2643] Fix circular dependency on pyspark starters](https://github.com/quantumblacklabs/kedro-starters/pull/41), given that a more permanent solution is now in place in Kedro's `master` (see [this](https://github.com/quantumblacklabs/kedro/commit/cd8cca82dae82fddbf9a485dab7b122bf24f8618)).

Related GitHub issues:
1. https://github.com/quantumblacklabs/kedro-starters/issues/38
2. https://github.com/quantumblacklabs/kedro/issues/767