### PR TITLE
Spaceflights - Update requirements and catalog so that openpyxl is taken over outdated xlrd

### DIFF
--- a/spaceflights/{{ cookiecutter.repo_name }}/conf/base/catalog.yml
+++ b/spaceflights/{{ cookiecutter.repo_name }}/conf/base/catalog.yml
@@ -55,6 +55,8 @@ shuttles:
   type: pandas.ExcelDataSet
   filepath: data/01_raw/shuttles.xlsx
   layer: raw
+  load_args:
+    engine: openpyxl
 
 preprocessed_companies:
   type: pandas.CSVDataSet

--- a/spaceflights/{{ cookiecutter.repo_name }}/src/requirements.txt
+++ b/spaceflights/{{ cookiecutter.repo_name }}/src/requirements.txt
@@ -6,7 +6,7 @@ jupyter~=1.0
 jupyter_client>=5.1, <7.0
 jupyterlab~=3.0
 kedro[pandas.CSVDataSet,pandas.ExcelDataSet]=={{ cookiecutter.kedro_version }}
-openpyxl==3.0.9
+openpyxl>=3.0.6, <4.0
 kedro-telemetry~=0.1.0
 kedro-viz~=3.1
 nbstripout~=0.4

--- a/spaceflights/{{ cookiecutter.repo_name }}/src/requirements.txt
+++ b/spaceflights/{{ cookiecutter.repo_name }}/src/requirements.txt
@@ -6,6 +6,7 @@ jupyter~=1.0
 jupyter_client>=5.1, <7.0
 jupyterlab~=3.0
 kedro[pandas.CSVDataSet,pandas.ExcelDataSet]=={{ cookiecutter.kedro_version }}
+openpyxl=3.0.9
 kedro-telemetry~=0.1.0
 kedro-viz~=3.1
 nbstripout~=0.4

--- a/spaceflights/{{ cookiecutter.repo_name }}/src/requirements.txt
+++ b/spaceflights/{{ cookiecutter.repo_name }}/src/requirements.txt
@@ -6,7 +6,7 @@ jupyter~=1.0
 jupyter_client>=5.1, <7.0
 jupyterlab~=3.0
 kedro[pandas.CSVDataSet,pandas.ExcelDataSet]=={{ cookiecutter.kedro_version }}
-openpyxl=3.0.9
+openpyxl==3.0.9
 kedro-telemetry~=0.1.0
 kedro-viz~=3.1
 nbstripout~=0.4


### PR DESCRIPTION
Currently the spaceflights tutorial will produce a long `xlrd` warning that will stay with Kedro until 0.18.0 drops 3.6 support. 

![image](https://user-images.githubusercontent.com/35801847/140608899-003baf12-d49a-4701-889d-5e412c75f36b.png)


By adding `openpyxl` to the requirements + setting as the default engine in the catalog the flow will be less terrifying to new users.