### PR TITLE
Bump kedro-viz version

### DIFF
--- a/spaceflights/{{ cookiecutter.repo_name }}/src/requirements.txt
+++ b/spaceflights/{{ cookiecutter.repo_name }}/src/requirements.txt
@@ -8,7 +8,8 @@ jupyterlab~=3.0
 kedro[pandas.CSVDataSet,pandas.ExcelDataSet]=={{ cookiecutter.kedro_version }}
 openpyxl>=3.0.6, <4.0
 kedro-telemetry~=0.1.0
-kedro-viz~=4.0
+kedro-viz==3.16.0; python_version=='3.6'
+kedro-viz~=4.0; python_version>'3.6'
 nbstripout~=0.4
 pytest-cov~=3.0
 pytest-mock>=1.7.1, <2.0

--- a/spaceflights/{{ cookiecutter.repo_name }}/src/requirements.txt
+++ b/spaceflights/{{ cookiecutter.repo_name }}/src/requirements.txt
@@ -8,7 +8,7 @@ jupyterlab~=3.0
 kedro[pandas.CSVDataSet,pandas.ExcelDataSet]=={{ cookiecutter.kedro_version }}
 openpyxl>=3.0.6, <4.0
 kedro-telemetry~=0.1.0
-kedro-viz~=3.1
+kedro-viz~=4.0
 nbstripout~=0.4
 pytest-cov~=3.0
 pytest-mock>=1.7.1, <2.0


### PR DESCRIPTION
## Motivation and Context
Seeing as we're meant to be encouraging people to upgrade kedro-viz, bumping the version in our starters seems like a good idea... `spaceflights` in the only one that has `kedro-viz` in the requirements.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Assigned myself to the PR
- [ ] Added tests to cover my changes

